### PR TITLE
Improves the website's keyboard accessibility

### DIFF
--- a/src/jsx/components/MainNav.jsx
+++ b/src/jsx/components/MainNav.jsx
@@ -21,6 +21,7 @@ class MainNav extends Component {
 	render() {
 		return (
 			<header role="banner" className="nav-container">
+				<a href="#searchTerm" class="skip-content visuallyhidden">Skip to content</a>
 				<div className="nav-items">
 					<div className="nav-logo">
 						<Link to="/">

--- a/src/jsx/components/Search.jsx
+++ b/src/jsx/components/Search.jsx
@@ -46,7 +46,7 @@ export default class Search extends Component {
 								onChange={this.handleChange.bind(this)}
 								value={this.state.currentSearchQuery}
 							/>
-							<button type="submit" className="search-button" title="Search">
+							<button type="submit" className="search-button" title="Search" tabindex="-1">
 								<SearchIcon />
 							</button>
 						</div>

--- a/src/jsx/pages/About.jsx
+++ b/src/jsx/pages/About.jsx
@@ -62,9 +62,9 @@ class About extends Component {
 										</a>
 									</div>
 								</div>
-								<div aria-hidden="true" id="infrastructure" className="modal-window">
+								<div aria-hidden="true" id="infrastructure" className="modal-window" role="dialog">
 									<div>
-										<a href="#" title="Close" className="modal-close">
+										<a href="#" title="Close" className="modal-close" role="button" aria-modal="true">
 											Close
 										</a>
 										<img src={Infra} alt="Infrastructure" />

--- a/src/jsx/pages/Search.jsx
+++ b/src/jsx/pages/Search.jsx
@@ -51,7 +51,7 @@ const Search = ({ searchMsg, showSearchMsg, value, onSubmit, onInputChange }) =>
 						onChange={onInputChange}
 						defaultValue={value}
 					/>
-					<button type="submit" className="search-button" title="Search">
+					<button type="submit" className="search-button" title="Search" tabindex="-1">
 						<SearchIcon />
 					</button>
 				</div>

--- a/src/scss/Result.scss
+++ b/src/scss/Result.scss
@@ -95,6 +95,11 @@ tbody tr {
         outline: 0;
       }
 
+      a:focus, a:active {
+        color: $openLawA11yBrown;
+        background: #fae8d9;
+      }
+
       margin-left: 8px;
       border-radius: 3px;
       background: none;

--- a/src/scss/Search.scss
+++ b/src/scss/Search.scss
@@ -143,7 +143,7 @@
     cursor: pointer;
     box-shadow: 0px 4px 13px rgba(0, 0, 0, 0.25);
     transition: 0.3s;
-    &:hover {
+    &:hover, &:focus {
       color: $openLawA11yBrown;
       background: #fae8d9;
     }


### PR DESCRIPTION
Progress on issue #58 

- Adds a skip-link so that users don't have to tab through the navigation on every page
- Makes the search magnifying glass not tabable since this functionality is already captured through 'enter' and the subsequent search button
- Makes the infrastructure image into an aria-modal so that keyboard-only users can close it
- Adds focus colours so that it's easier to see what element the keyboard is interacting with