### PR TITLE
Fix to react-helmet import in seo component

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -7,7 +7,7 @@
 
 import React from "react"
 import PropTypes from "prop-types"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 function SEO({ description, lang, meta, title }) {


### PR DESCRIPTION
When I spun up a dev environment this morning I found that upgrading to React Helmet version 6 in 89c4adacecb0d2b258fb648118ee24f3072452b9 had introduced a breaking change. Simple fix, just importing helmet as named module instead of as a default import
___
NB - by making a pull request you confirm agreement to the [Contributors Agreement](https://github.com/openlawnz/openlawnz-web/blob/master/CONTRIBUTING.md).

