### PR TITLE
fix/248-remove-z-index-main-search

### DIFF
--- a/src/scss/Search.scss
+++ b/src/scss/Search.scss
@@ -9,7 +9,6 @@
     display: flex;
     width: 100%;
     max-width: 320px;
-    z-index: 100;
   }
 
   .input-wrapper {


### PR DESCRIPTION
Fixing #248 :
Removed `z-index` from main search field.

(first issue to get familiar with the workflow and contributing guidelines)