### PR TITLE
fix/447-listbox-ui-improvements

### DIFF
--- a/src/scss/AdvancedSearch.scss
+++ b/src/scss/AdvancedSearch.scss
@@ -34,6 +34,9 @@
 
     &__item {
       padding: 7px 15px;
+      text-align: left;
+      width: 100%;
+      border-top: 1px solid $openLawLightGray;
 
       &:not(.listBox__item--clean):hover,
       &-focused {


### PR DESCRIPTION
Fixing issue #447 :
- Text in each list element to be left-aligned instead of centered.
- Text highlight covering entire list element when hovering.
- List elements to be separated more clearly.

![image](https://user-images.githubusercontent.com/1905292/82268852-1436d900-99c4-11ea-9503-194652608655.png)



