### PR TITLE
Add ModuleSelector Component

### DIFF
--- a/content/get-involved/community-engagement.json
+++ b/content/get-involved/community-engagement.json
@@ -5,7 +5,7 @@
     {
       "type": "text",
       "title": "Summary",
-      "group": [
+      "content": [
         {
           "content_html": "We will help community law centres, citizens advice, and other people in need of legal information and assistance as much as we can. We are always keen to hear feedback from our stakeholders. ",
           "title": "Community"

--- a/content/get-involved/law-firms.json
+++ b/content/get-involved/law-firms.json
@@ -5,7 +5,7 @@
     {
       "type": "text",
       "title": "Summary",
-      "group": [
+      "content": [
         {
           "content_html": "OpenLaw NZ technology will help lawyers and law firms become more efficient and better resourced. Our case law API can be used to build custom research solutions and document tools. Our advanced search and researcher interface can be used to export and analyse case law data at scale.  ",
           "title": "OpenLaw NZ technology"
@@ -15,7 +15,7 @@
     {
       "type": "text",
       "title": "API Integrations",
-      "group": [
+      "content": [
         {
           "content_html": "The OpenLaw NZ API facilitates access and interaction with machine-readable legal data. It means legal data can be integrated and used inside your own applications, document management software, and Microsoft Word. ",
           "title": "The OpenLaw NZ API facilitates access..."
@@ -36,7 +36,7 @@
     },
     {
       "type": "text",
-      "group": [
+      "content": [
         {
           "content_html": "Our platform can be used to automate the analysis of large amounts of case law very quickly. We’re currently building a prototype researcher interface to facilitate this. If you’re interested, drop us a line. ",
           "title": "Analysis"

--- a/content/get-involved/our-volunteers.json
+++ b/content/get-involved/our-volunteers.json
@@ -5,7 +5,7 @@
     {
       "type": "text",
       "title": "Summary",
-      "group": [
+      "content": [
         {
           "content_html": "OpenLaw NZ is a registered charity. We’re operated by a fantastic group of volunteers, helping with code, design, orchestration, data parsing, machine learning and devops. ",
           "title": "OpenLaw NZ is a registered charity. We’re operated by a fantastic group of volunteers..."

--- a/content/get-involved/universities.json
+++ b/content/get-involved/universities.json
@@ -5,7 +5,7 @@
     {
       "type": "text",
       "title": "Academics",
-      "group": [
+      "content": [
         {
           "content_html": "Our platform can be used to automate the analysis of large amounts of case law very quickly. We’re currently building a prototype researcher interface to facilitate this. If you’re interested, drop us a line. ",
           "title": "Automation"
@@ -19,7 +19,7 @@
     {
       "type": "text",
       "title": "Law Students",
-      "group": [
+      "content": [
         {
           "title": "Uses",
           "content_html": "Law students can use OpenLaw NZ to: \n\n<ul>\n<li>Carry out legal research</li>\n<li>Explore legal data and discover new insights by analysing data at scale </li>\n<li>For the more adventurous, build innovative tools for the public using our API </li>\n</ul>\n\nYou may also be able to contribute to the development of the OpenLaw NZ platform.  "

--- a/content/get-involved/volunteering.json
+++ b/content/get-involved/volunteering.json
@@ -5,7 +5,7 @@
     {
       "type": "text",
       "title": "Code and development  ",
-      "group": [
+      "content": [
         {
           "content_html": "Our software is open-source software, and that means anybody can browse our github repositories and submit a pull request to improve parts of our code. We maintain an active list of issues under each of our repositories.  ",
           "title": "Software"
@@ -19,7 +19,7 @@
     {
       "type": "text",
       "title": "Write with us ",
-      "group": [
+      "content": [
         {
           "content_html": "We’re building areas in our website devoted to increasing general knowledge about specific areas of law. An example is our credit contracts area. If you are interested in writing or contributing to a topic, and are interested in building innovative technology, our development team can help bring your ideas to life.  ",
           "title": "Website Expansion"
@@ -37,7 +37,7 @@
     {
       "type": "text",
       "title": "Other areas",
-      "group": [
+      "content": [
         {
           "title": "Seek Volunteer",
           "content_html": "Occasionally we list other volunteer positions on seek volunteer. You can browse all our listings at our <a href=\"https://seekvolunteer.co.nz/volunteering-organisations/1567/openlaw-nz-ltd\">organisation page</a> there. "
@@ -47,7 +47,7 @@
     {
       "type": "text",
       "title": "Why Contribute?",
-      "group": [
+      "content": [
         {
           "title": "Why Contribute?",
           "content_html": "Your contributions to OpenLaw NZ: \n<ul>\n<li>Are peer reviewed for code and writing (through Github, OpenLaw NZ slack)</li>\n<li>Integrate with high quality designs </li>\n<li>Will be open source and permanent </li>\n<li>Can be integrated into our research platform (eg related cases) </li>\n</ul>"

--- a/content/our-mission/about-us.json
+++ b/content/our-mission/about-us.json
@@ -5,7 +5,7 @@
     {
       "type": "text",
       "title": "Summary",
-      "group": [
+      "content": [
         {
           "content_html": "OpenLaw NZ is an open-source legal data platform. Our goal is to improve the accessibility of case law and other legal information in New Zealand. We want to make it easier for all New Zealanders to understand law. ",
           "title": "What Openlaw is"

--- a/content/our-mission/financials.json
+++ b/content/our-mission/financials.json
@@ -5,7 +5,7 @@
     {
       "type": "text",
       "title": "Financial reports ",
-      "group": [
+      "content": [
         {
           "title": "Links",
           "content_html": "<ul>\n<li>\n<a>Year ending 31 March 2019</a>\n</li>\n<li>\n<a>Year ending 31 March 2020</a>\n</li>\n</ul>"
@@ -15,7 +15,7 @@
     {
       "type": "text",
       "title": "Legal Documents",
-      "group": [
+      "content": [
         {
           "title": "Constitution",
           "content_html": "<a>OpenLaw NZ Constitution</a."

--- a/content/our-mission/our-data.json
+++ b/content/our-mission/our-data.json
@@ -4,7 +4,7 @@
   "content": [
     {
       "type": "text",
-      "group": [
+      "content": [
         {
           "content_html": "The Ministry of Justice has kindly allowed us access to their database of case law from Judicial Decisions Online and other websites. Because case law is not subject to copyright restrictions, we have been able to re-purpose those PDFs and convert them into usable pieces of data that a computer can read.  ",
           "title": "Access"
@@ -23,7 +23,7 @@
     {
       "type": "text",
       "title": "Stewardship",
-      "group": [
+      "content": [
         {
           "title": "We want to make legal information as accessible as we can.  ",
           "content_html": "We want to make legal information as accessible as we can.  "

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -122,7 +122,7 @@ exports.createPages = async ({graphql, actions: { createPage } }) => {
               name
               image_url
             }
-            group {
+            content {
               content_html
               title
             }
@@ -138,7 +138,7 @@ exports.createPages = async ({graphql, actions: { createPage } }) => {
           content {
             title
             type
-            group {
+            content {
               title
               content_html
             }

--- a/src/components/ModuleSelector.jsx
+++ b/src/components/ModuleSelector.jsx
@@ -19,7 +19,7 @@ const ModuleSelector = (props) => {
       case "text": // Single heading, multiple paragraphs.
         return (
           <div name={title} className="module-block">
-            <h3>{module.title}</h3>
+            <h3 >{module.title}</h3>
             {
               module.content.map(({content_html}, idx) => {
                 return (

--- a/src/components/ModuleSelector.jsx
+++ b/src/components/ModuleSelector.jsx
@@ -11,7 +11,7 @@ const ModuleSelector = (props) => {
     const errorModule = (message) => {
       return <div className="microsite-paragraph" name={title}>
         <h4>{module.title}</h4>
-        Error: {message}
+        <p>Error: {message}</p>
       </div>
     }
     
@@ -23,7 +23,7 @@ const ModuleSelector = (props) => {
             {
               module.content.map(({content_html}, idx) => {
                 return (
-                  <div key={idx}
+                  <p key={idx}
                     className="microsite-paragraph"
                     dangerouslySetInnerHTML={{ __html: content_html }}
                   />
@@ -90,9 +90,7 @@ const ModuleSelector = (props) => {
             </div>
             )
         default: //Error Paragraph
-            return (
-            errorModule("Module type not found")
-            )
+            return errorModule("Module type not found")
     }
 }
 

--- a/src/components/ModuleSelector.jsx
+++ b/src/components/ModuleSelector.jsx
@@ -1,0 +1,99 @@
+import React from "react"
+import Accordion from "../components/Accordion"
+import Wizard from "../components/Wizard/Wizard"
+
+const ModuleSelector = (props) => {
+    
+    module = props.module
+
+    let title = module.title.replace(/\s/g, '-').toLowerCase()
+    
+    const errorModule = (message) => {
+      return <div className="microsite-paragraph" name={title}>
+        <h4>{module.title}</h4>
+        Error: {message}
+      </div>
+    }
+    
+    switch(module.type) { 
+      case "text": // Single heading, multiple paragraphs.
+        return (
+          <div name={title} className="module-block">
+            <h3>{module.title}</h3>
+            {
+              module.content.map(({content_html}, idx) => {
+                return (
+                  <div key={idx}
+                    className="microsite-paragraph"
+                    dangerouslySetInnerHTML={{ __html: content_html }}
+                  />
+                ) 
+              })
+            }
+          </div>
+        )
+        case "faqs":
+            return (
+            <div name={title}  className="module-block">
+                <h4>{module.title}</h4>
+                <Accordion id={`faqs-${props.idx}`} items={module.content.map(faq => {
+                return { title: faq.question, content: faq.answer }
+                })}/>
+            </div>
+            )
+        case "contributors":
+            return (
+              <div>
+                <h3>{module.title}</h3>
+                <div className="cards-list">
+                  {
+                    module.contributors.map(({image_url, title}, idx) => {
+                      return(
+                        <div key={idx} className="card-item-small">
+                          <div>
+                            <img src={image_url} alt={title}/>
+                            <strong>{title}</strong>
+                          </div>
+                        </div>
+                      )
+                    })
+                  }
+                </div>
+              </div>
+            )
+        case "directors":
+            return (
+                <div>
+                <h3>{module.title}</h3>
+                <div className="cards-list directors">
+                    {module.directors.map(({name, bio, image_url}, idx) => {
+                    return (
+                        <div className="card-item" key={idx}>
+                        <img src={image_url} alt={name}></img>
+                        <strong>{name}</strong>
+                        <p>{bio}</p>
+                        </div>
+                    )
+                    })}
+                </div>
+                
+                </div>
+            )
+        case "wizard":
+            // This is uncomfortably fragile but the Netlify CMS does not support auto-generated ID/key fields
+            // as of 29/05/2020
+            const wizardData = props.wizardData.find(wizard => wizard.key === module.wizard)
+            if (!wizardData) return errorModule("Wizard data not found")
+            return (
+            <div className="module-block" name={wizardData.title.replace(/\s/g, '-').toLowerCase()}>
+                <Wizard title={wizardData.title} background={wizardData.background} steps={wizardData.steps} />
+            </div>
+            )
+        default: //Error Paragraph
+            return (
+            errorModule("Module type not found")
+            )
+    }
+}
+
+export default ModuleSelector

--- a/src/components/ModuleSelector.jsx
+++ b/src/components/ModuleSelector.jsx
@@ -19,7 +19,7 @@ const ModuleSelector = (props) => {
       case "text": // Single heading, multiple paragraphs.
         return (
           <div name={title} className="module-block">
-            <h3 >{module.title}</h3>
+            <h3>{module.title}</h3>
             {
               module.content.map(({content_html}, idx) => {
                 return (

--- a/src/components/TertiaryNav.jsx
+++ b/src/components/TertiaryNav.jsx
@@ -17,11 +17,12 @@ const TertiaryNav = props => {
               <div key={idx}>
               {
                 <>  
+                <li className="tertiary-item">
                   <Link to={(props.base + "/" + toSlug(content[1]))}
                   activeClassName="tertiary-active">
 
-                  <li className="tertiary-item">{content[0]}</li>
                   </Link>
+                  </li>
                   {
                     content[0] === props.page &&
                     <>
@@ -29,11 +30,11 @@ const TertiaryNav = props => {
                         {
                           props.secondary_data.map((x, idx) => {
                             return (
-                              <Link to={(props.base + "/" + toSlug(content[1])) + "#" + toSlug(x)} key={idx}>
-                                <li>
-                                  {x}
-                                </li>
-                              </Link>
+                              <li>
+                                <Link to={(props.base + "/" + toSlug(content[1])) + "#" + toSlug(x)} key={idx}>
+                                 {x}
+                                </Link>
+                              </li>
                             )  
                           })
                         }

--- a/src/components/TertiaryNav.jsx
+++ b/src/components/TertiaryNav.jsx
@@ -21,6 +21,7 @@ const TertiaryNav = props => {
                   <Link to={(props.base + "/" + toSlug(content[1]))}
                   activeClassName="tertiary-active">
 
+                  {content[0]}
                   </Link>
                   </li>
                   {

--- a/src/components/TertiaryNav.jsx
+++ b/src/components/TertiaryNav.jsx
@@ -3,51 +3,51 @@ import React from "react"
 import { Link } from "gatsby"
 
 const TertiaryNav = props => {
+
+  const toSlug = (string) => {
+    return string.replace(/\s/g, '-').toLowerCase()
+  }
+  
   return (
     <div className="tertiary-nav">
-          <ul className="primary-menu">
+      <ul className="primary-menu">
+        {
+          props.data.map((content, idx) => {  
+            return (
+              <div key={idx}>
               {
-                  props.data.map((content, idx) => {
-                      return (
-                        <div key={idx}>
+                <>  
+                  <Link to={(props.base + "/" + toSlug(content[1]))}
+                  activeClassName="tertiary-active">
 
-                          {
-                            <>  
-                              <Link to={(props.base + "/" + content.replace(/\s/g, '-').toLowerCase())}
-                               activeClassName="tertiary-active">
-
-                                <li className="tertiary-item">{content}</li>
+                  <li className="tertiary-item">{content[0]}</li>
+                  </Link>
+                  {
+                    content[0] === props.page &&
+                    <>
+                      <ul className="tertiary-sub-routes">
+                        {
+                          props.secondary_data.map((x, idx) => {
+                            return (
+                              <Link to={(props.base + "/" + toSlug(content[1])) + "#" + toSlug(x)} key={idx}>
+                                <li>
+                                  {x}
+                                </li>
                               </Link>
-                              {
-                                content === props.page &&
-                                <>
-                                 <ul className="tertiary-sub-routes">
-                                    {
-                                      props.secondary_data.map((x, idx) => {
-                                        return (
-                                        <Link to={(props.base + "/" + content.replace(/\s/g, '-').toLowerCase()) + "#" + x.replace(/\s/g, '-').toLowerCase()} key={idx}>
-                                            <li>
-                                              {x}
-                                            </li>
-                                          </Link>
-                                        )
-                                      })
-                                    }
-                                </ul>
-                                </>
-                              }
-                             
-                            </>
-                          }
-                         
-                        </div>
-
-                        
-                      )
-                  })
-              }
-          </ul>
-      </div>
+                            )  
+                          })
+                        }
+                      </ul>
+                    </>
+                  }
+                </>
+                }
+              </div>
+            )
+          })
+        }
+      </ul>
+    </div>
   )
 }
 

--- a/src/pages/get-empowered.js
+++ b/src/pages/get-empowered.js
@@ -2,32 +2,44 @@ import React from "react"
 import SEO from "../components/seo"
 import Layout from "../components/layout"
 import {Link, graphql} from "gatsby"
-// import TertiaryNav from "../components/TertiaryNav.jsx"
+import TertiaryNav from "../components/TertiaryNav.jsx"
 
 
 const EmpowerPage = ({ data }) => {
     const micrositeData = data.allMicrositesJson.edges.map(n => n.node)
-    
+  
+  const toSlug = (string) => {
+    return string.replace(/\s/g, '-').toLowerCase()
+  }
+
   return (
     <Layout>
       <SEO title="Get Empowered" />  
-      <div className="side-wrapper">
-        <div className="container main">
-          <div className="content">
-          <h1>Get Empowered</h1>
-            {
-              micrositeData.map(({title, description, fields, content}, idx) => {
-                  return (
-                    <div className="microsite-paragraph" key={idx}>
-                        <h3 name={fields.slug.slice(1)}>{title}</h3>
-                        <p>{description}</p>
-                        <Link to={`/get-empowered/${fields.slug}/${content[0].title.replace(/\s/g, '-').toLowerCase()}`}>View Site</Link>
-                    </div>
-                  )
-              }) 
-            }
+      <div className="tertiary-background">
+        <div className="side-wrapper">
+          <div className="container main">
+            <div className="content">
+            <h1>Get Empowered</h1>
+              {
+                micrositeData.map(({title, description, fields, content}, idx) => {
+                    return (
+                      <div className="microsite-paragraph" key={idx}>
+                          <h3 name={fields.slug.slice(1)}>{title}</h3>
+                          <p>{description}</p>
+                          <Link to={`/get-empowered/${fields.slug}/${toSlug(content[0].title)}`}>View Site</Link>
+                      </div>
+                    )
+                }) 
+              }
+            </div>
           </div>
         </div>
+        <TertiaryNav 
+        base= "/get-empowered/"
+        data={micrositeData.map(({title, content}) =>  {
+            return [title,`${toSlug(title)}/${toSlug(content[0].title)}`]
+        })}
+        />
       </div>
     </Layout>
   )

--- a/src/pages/get-involved.js
+++ b/src/pages/get-involved.js
@@ -34,11 +34,10 @@ const getInvolvedPage = ({data}) => {
         <TertiaryNav 
         base="/get-involved/" 
         data={
-            pageContext.map(({title}) =>  {
-            return title
-        })  
-        }
-        type="/"/>
+          pageContext.map(({title}) =>  {
+            return [title, title]
+          })  
+        }/>
         </div>
     </Layout>
   )

--- a/src/pages/our-mission.js
+++ b/src/pages/our-mission.js
@@ -35,10 +35,9 @@ const ourMissionPage = ({data}) => {
       base="/our-mission/" 
       data={
         pageContext.map(({title}) =>  {
-          return title
+          return [title, title]
       })  
-      }
-      type="/"/>
+      }/>
       </div>
     </Layout>
   )

--- a/src/scss/Microsite.scss
+++ b/src/scss/Microsite.scss
@@ -3,6 +3,10 @@
     padding-top: 10px;
   }
   .module-block {
+
+    margin-top: -70px; //causes anchor links to jump above block so it is not concealed by nav
+    padding-top: 70px;
+
     padding-bottom: 25px;
   }
  

--- a/src/scss/Nav.scss
+++ b/src/scss/Nav.scss
@@ -424,15 +424,16 @@
 
   .tertiary-item {
     width: 100%;
-    padding: 12px 0 12px 10px;
     border-bottom: 1px solid $openLawA11yBrown;
     line-height: 1.2;
+    a {
+      display: block;
+      padding: 12px 0 12px 10px;
+    }
   }
   
   .tertiary-active {
-    li {
-      border-bottom: 4px solid $openLawA11yBrown;
-    }
+    border-bottom: 3px solid $openLawA11yBrown;
   }
 
 
@@ -442,6 +443,9 @@
       font-size: 16px;
       padding-top: 10px;
       font-weight: 600;
+      a:hover {
+        color: $openLawA11yBrown;
+      }
     }
   }
 

--- a/src/scss/Nav.scss
+++ b/src/scss/Nav.scss
@@ -426,7 +426,7 @@
     width: 100%;
     padding: 12px 0 12px 10px;
     border-bottom: 1px solid $openLawA11yBrown;
-    line-height: 1;
+    line-height: 1.2;
   }
   
   .tertiary-active {

--- a/src/templates/get-involved-page.js
+++ b/src/templates/get-involved-page.js
@@ -1,60 +1,9 @@
 import React from "react"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
+import ModuleSelector from "../components/ModuleSelector"
 
 const GetInvolvedPage = ({ pageContext }) => {
-
-  function selectModule(module) {
-    const errorModule = (message) => {
-      return <div className="microsite-paragraph">
-        <h4>{module.title}</h4>
-        Error: {message}
-      </div>
-    }
-    switch(module.type) {
-      case "text":
-        return ( 
-          <div className="module-block">
-            <h3>{module.title}</h3>
-            {
-              module.group.map(({content_html}, idx) => {
-                return (
-                  <div key={idx}
-                    className="microsite-paragraph"
-                    dangerouslySetInnerHTML={{ __html: content_html }}
-                  />
-                ) 
-              })
-            }
-          </div>
-        )
-        case "contributors":
-            return (
-              <div>
-                <h3>{module.title}</h3>
-                <div className="cards-list">
-                  {
-                    module.contributors.map(({image_url, title}, idx) => {
-                      return(
-                        <div key={idx} className="card-item-small">
-                          <div>
-                            <img src={image_url} alt={title}/>
-                            <strong>{title}</strong>
-                          </div>
-                        </div>
-                      )
-                    })
-                  }
-                </div>
-              </div>
-            )
-      default:
-        return (
-          errorModule("Module type not found")
-        )
-    }
-  }
-
   return (
   <Layout>
       <SEO title={pageContext.title} description={pageContext.description} />
@@ -65,7 +14,7 @@ const GetInvolvedPage = ({ pageContext }) => {
             pageContext.content.map((module, idx) => {
               return (
                 <div key={idx}>
-                  {selectModule(module)}
+                  <ModuleSelector module={module} wizardData={pageContext.wizardData} idx={idx}/>
                 </div>
               )
             })

--- a/src/templates/microsite.js
+++ b/src/templates/microsite.js
@@ -2,64 +2,9 @@ import React from "react"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import TertiaryNav from "../components/TertiaryNav.jsx"
-import Accordion from "../components/Accordion"
-import Wizard from "../components/Wizard/Wizard"
 
+import ModuleSelector from "../components/ModuleSelector"
 const Microsite = ({ pageContext }) => {
-  
-  function selectModule(module, idx) { //selects the correct module type
-    let title = module.title.replace(/\s/g, '-').toLowerCase()
-
-    const errorModule = (message) => {
-      return <div className="microsite-paragraph" key={idx} name={title}>
-        <h4>{module.title}</h4>
-        Error: {message}
-      </div>
-    }
-    
-    switch(module.type) { 
-      case "text": // Single heading, multiple paragraphs.
-        return (
-          <div key={idx} name={title} className="module-block">
-            <h3>{module.title}</h3>
-            {
-              module.content.map(({content_html}, idx) => {
-                return (
-                  <div key={idx}
-                    className="microsite-paragraph"
-                    dangerouslySetInnerHTML={{ __html: content_html }}
-                  />
-                ) 
-              })
-            }
-          </div>
-        )
-      case "faqs":
-        return (
-          <div key={idx} name={title}  className="module-block">
-            <h4>{module.title}</h4>
-            <Accordion id={`faqs-${idx}`} items={module.content.map(faq => {
-              return { title: faq.question, content: faq.answer }
-            })}/>
-          </div>
-        )
-      case "wizard":
-        // This is uncomfortably fragile but the Netlify CMS does not support auto-generated ID/key fields
-        // as of 29/05/2020
-        const wizardData = pageContext.wizardData.find(wizard => wizard.key === module.wizard)
-        if (!wizardData) return errorModule("Wizard data not found")
-        return (
-          <div key={idx} className="module-block" name={wizardData.title.replace(/\s/g, '-').toLowerCase()}>
-            <Wizard title={wizardData.title} background={wizardData.background} steps={wizardData.steps} />
-          </div>
-        )
-      default: //Error Paragraph
-        return (
-          errorModule("Module type not found")
-        )
-    }
-  }
-
   return (
   <Layout>
   <SEO title={`${pageContext.title} - ${pageContext.section.title}`} description={pageContext.description} />
@@ -74,7 +19,7 @@ const Microsite = ({ pageContext }) => {
                 
                 return (
                   <div key={idx}>
-                    {selectModule(module, idx)}
+                    <ModuleSelector module={module} wizardData={pageContext.wizardData} idx={idx}/>
                   </div>
                 )
               })

--- a/src/templates/microsite.js
+++ b/src/templates/microsite.js
@@ -31,7 +31,7 @@ const Microsite = ({ pageContext }) => {
     <TertiaryNav 
       base={"/get-empowered/" + pageContext.title.replace(/\s/g, '-').toLowerCase()} 
       data={pageContext.section_headings.map((x) =>  {
-          return x
+          return [x, x]
       })}
       secondary_data={pageContext.section.modules.map(x => x.title)}
       type="/"

--- a/src/templates/news.js
+++ b/src/templates/news.js
@@ -21,10 +21,9 @@ const News = ({ pageContext }) => (
         base="/news/" 
         data={
           pageContext.news.map(({title}) =>  {
-            return title
+            return [title, title]
         })  
-        }
-        type="/"/>
+        }/>
     </div>
   </Layout>
 )

--- a/src/templates/our-mission-page.js
+++ b/src/templates/our-mission-page.js
@@ -1,77 +1,10 @@
 import React from "react"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
+import ModuleSelector from "../components/ModuleSelector"
 
 const OurMissionPage = ({ pageContext }) => {
 
-  function selectModule(module) {
-    const errorModule = (message) => {
-      return <div className="microsite-paragraph">
-        <h4>{module.title}</h4>
-        Error: {message}
-      </div>
-    }
-    switch(module.type) {
-      case "text":
-        return ( 
-          <div className="module-block">
-            <h3>{module.title}</h3>
-            {
-              module.group.map(({content_html}, idx) => {
-                return (
-                  <div key={idx}
-                    className="microsite-paragraph"
-                    dangerouslySetInnerHTML={{ __html: content_html }}
-                  />
-                ) 
-              })
-            }
-          </div>
-        )
-      case "contributors":
-        return (
-          <div>
-            <h3>{module.title}</h3>
-            <div className="cards-list">
-              {
-                module.contributors.map(({image_url, title}, idx) => {
-                  return(
-                    <div key={idx} className="card-item-small">
-                      <div>
-                        <img src={image_url} alt={title}/>
-                        <strong>{title}</strong>
-                      </div>
-                    </div>
-                  )
-                })
-              }
-            </div>
-          </div>
-        )
-      case "directors":
-        return (
-          <div>
-            <h3>{module.title}</h3>
-            <div className="cards-list directors">
-              {module.directors.map(({name, bio, image_url}, idx) => {
-                return (
-                  <div className="card-item" key={idx}>
-                    <img src={image_url} alt={name}></img>
-                    <strong>{name}</strong>
-                    <p>{bio}</p>
-                  </div>
-                )
-              })}
-            </div>
-            
-          </div>
-        )
-      default:
-        return (
-          errorModule("Module type not found")
-        )
-    }
-  }
 
   return (
   <Layout>
@@ -83,7 +16,7 @@ const OurMissionPage = ({ pageContext }) => {
             pageContext.content.map((module, idx) => {
               return (
                 <div key={idx}>
-                  {selectModule(module)}
+                  <ModuleSelector module={module} wizardData={pageContext.wizardData} idx={idx}/>
                 </div>
               )
             })

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -242,7 +242,7 @@ collections:
               - { name: title, Label: Title}
               - label: Text
                 label_singular: Text
-                name: group
+                name: content
                 widget: list
                 fields:
                   - { name: title, label: "Summary", hint: "This will not appear on the page" }
@@ -300,7 +300,7 @@ collections:
               - { name: title, Label: Title}
               - label: Text
                 label_singular: Text
-                name: group
+                name: content
                 widget: list
                 fields:
                   - { name: title, label: "Summary", hint: "This will not appear on the page" }


### PR DESCRIPTION
Previously all content pages (Our Mission/Get Involved/Get Empowered) had a function to handle each module that was in their config. Most of these overlapped and so I've moved them into one component that handles it for all of these pages, saves repeating the same code in 3 different locations.

Also fixed the line height issue on content pages.
___
NB - by making a pull request you confirm agreement to the [Contributors Agreement](https://github.com/openlawnz/openlawnz-web/blob/master/CONTRIBUTING.md).

