### PR TITLE
Reduced wizard background image opacity using an overlay

### DIFF
--- a/src/components/Wizard/Wizard.jsx
+++ b/src/components/Wizard/Wizard.jsx
@@ -31,7 +31,7 @@ export default function Wizard({ background, title, steps }) {
           <WizardStart title={title} start={() => dispatch({ type: WizardOperations.NEXT, payload: steps[0].key })} />
         ) : (
           <WizardStep
-            step={steps.find((step) => step.key === wizardStack[wizardStack.length - 1])}
+            step={steps.find(({ key }) => key === wizardStack[wizardStack.length - 1])}
             navigate={dispatch}
           />
         )}

--- a/src/components/Wizard/Wizard.jsx
+++ b/src/components/Wizard/Wizard.jsx
@@ -26,11 +26,16 @@ export default function Wizard({ background, title, steps }) {
 
   return (
     <section className="wizard" style={{ backgroundImage: `url(${background})` }}>
-      {wizardStack.length === 0 ? (
-        <WizardStart title={title} start={() => dispatch({ type: WizardOperations.NEXT, payload: steps[0].key })} />
-      ) : (
-        <WizardStep step={steps.find((step) => step.key === wizardStack[wizardStack.length - 1])} navigate={dispatch} />
-      )}
+      <div className="wizard-bg-overlay">
+        {wizardStack.length === 0 ? (
+          <WizardStart title={title} start={() => dispatch({ type: WizardOperations.NEXT, payload: steps[0].key })} />
+        ) : (
+          <WizardStep
+            step={steps.find((step) => step.key === wizardStack[wizardStack.length - 1])}
+            navigate={dispatch}
+          />
+        )}
+      </div>
     </section>
   )
 }

--- a/src/scss/Wizard.scss
+++ b/src/scss/Wizard.scss
@@ -3,8 +3,12 @@
   background-position: bottom right;
   background-repeat: no-repeat;
   background-size: contain;
-  padding: 20px 30px;
   position: relative;
+}
+
+.wizard-bg-overlay {
+  background: rgba(255, 255, 255, 0.8);
+  padding: 20px 30px;
 }
 
 .wizard-start {
@@ -114,5 +118,9 @@
   .wizard-step-content {
     min-height: 300px;
     padding: 20px 0;
+  }
+
+  .wizard-step-option {
+    flex-basis: 100%;
   }
 }


### PR DESCRIPTION
No idea why I couldn't figure out how to do this first time around, it's not exactly difficult. Anyway, this should make the content a lot easier to read. There's a minor responsiveness improvement for the options as well.
___
NB - by making a pull request you confirm agreement to the [Contributors Agreement](https://github.com/openlawnz/openlawnz-web/blob/master/CONTRIBUTING.md).

